### PR TITLE
Fix: Rename TableName to DbObjectName

### DIFF
--- a/StarRezApiClient/ApiObject.cs
+++ b/StarRezApiClient/ApiObject.cs
@@ -25,7 +25,7 @@ namespace StarRezApi
 		/// <summary>
 		/// Gets the name of the source table for the record that this object represents
 		/// </summary>
-		public string TableName
+		public string DbObjectName
 		{
 			get
 			{

--- a/StarRezApiClient/ApiObject.cs
+++ b/StarRezApiClient/ApiObject.cs
@@ -25,7 +25,7 @@ namespace StarRezApi
 		/// <summary>
 		/// Gets the name of the source table for the record that this object represents
 		/// </summary>
-		public string DbObjectName
+		public string DBObjectName
 		{
 			get
 			{

--- a/StarRezApiClient/StarRezApiClient.cs
+++ b/StarRezApiClient/StarRezApiClient.cs
@@ -167,10 +167,10 @@ namespace StarRezApi
 			XElement errors = GetErrorsXml(autoFixErrors, autoIgnoreErrors, errorsToIgnore, errorsToFix, errorsToNotIgnore, errorsToNotFix);
 			xml.Add(errors);
 			XElement result;
-			HttpStatusCode status = PerformRequest(string.Join("/", "create", record.TableName), xml, out result);
+			HttpStatusCode status = PerformRequest(string.Join("/", "create", record.DbObjectName), xml, out result);
 			if (status == HttpStatusCode.OK)
 			{
-				return Convert.ToInt32(result.Element(record.TableName + "ID").Value);
+				return Convert.ToInt32(result.Element(record.DbObjectName + "ID").Value);
 			}
 			return -1;
 		}
@@ -299,7 +299,7 @@ namespace StarRezApi
 			XElement errors = GetErrorsXml(autoFixErrors, autoIgnoreErrors, errorsToIgnore, errorsToFix, errorsToNotIgnore, errorsToNotFix);
 			xml.Add(errors);
 			XElement result;
-			HttpStatusCode status = PerformRequest(string.Join("/", "update", record.TableName, record.ID), xml, out result);
+			HttpStatusCode status = PerformRequest(string.Join("/", "update", record.DbObjectName, record.ID), xml, out result);
 			if (status == HttpStatusCode.OK)
 			{
 				record.ClearChanges();
@@ -327,7 +327,7 @@ namespace StarRezApi
 		{
 			if (record == null) throw new ArgumentNullException("record");
 
-			return Delete(record.TableName, Convert.ToInt32(record.ID), autoFixErrors, autoIgnoreErrors, errorsToIgnore, errorsToFix, errorsToNotIgnore, errorsToNotFix);
+			return Delete(record.DbObjectName, Convert.ToInt32(record.ID), autoFixErrors, autoIgnoreErrors, errorsToIgnore, errorsToFix, errorsToNotIgnore, errorsToNotFix);
 		}
 
 		/// <summary>

--- a/StarRezApiClient/StarRezApiClient.cs
+++ b/StarRezApiClient/StarRezApiClient.cs
@@ -167,10 +167,10 @@ namespace StarRezApi
 			XElement errors = GetErrorsXml(autoFixErrors, autoIgnoreErrors, errorsToIgnore, errorsToFix, errorsToNotIgnore, errorsToNotFix);
 			xml.Add(errors);
 			XElement result;
-			HttpStatusCode status = PerformRequest(string.Join("/", "create", record.DbObjectName), xml, out result);
+			HttpStatusCode status = PerformRequest(string.Join("/", "create", record.DBObjectName), xml, out result);
 			if (status == HttpStatusCode.OK)
 			{
-				return Convert.ToInt32(result.Element(record.DbObjectName + "ID").Value);
+				return Convert.ToInt32(result.Element(record.DBObjectName + "ID").Value);
 			}
 			return -1;
 		}
@@ -299,7 +299,7 @@ namespace StarRezApi
 			XElement errors = GetErrorsXml(autoFixErrors, autoIgnoreErrors, errorsToIgnore, errorsToFix, errorsToNotIgnore, errorsToNotFix);
 			xml.Add(errors);
 			XElement result;
-			HttpStatusCode status = PerformRequest(string.Join("/", "update", record.DbObjectName, record.ID), xml, out result);
+			HttpStatusCode status = PerformRequest(string.Join("/", "update", record.DBObjectName, record.ID), xml, out result);
 			if (status == HttpStatusCode.OK)
 			{
 				record.ClearChanges();
@@ -327,7 +327,7 @@ namespace StarRezApi
 		{
 			if (record == null) throw new ArgumentNullException("record");
 
-			return Delete(record.DbObjectName, Convert.ToInt32(record.ID), autoFixErrors, autoIgnoreErrors, errorsToIgnore, errorsToFix, errorsToNotIgnore, errorsToNotFix);
+			return Delete(record.DBObjectName, Convert.ToInt32(record.ID), autoFixErrors, autoIgnoreErrors, errorsToIgnore, errorsToFix, errorsToNotIgnore, errorsToNotFix);
 		}
 
 		/// <summary>


### PR DESCRIPTION
To resolve issues where TableName is used as a column on some StarRez tables.

This is possibly a breaking change, although the chances of anyone using TableName from ApiObject are slim.